### PR TITLE
ZON-5767: Make gdpr layer configurable in blog options

### DIFF
--- a/zon_blog_extensions.php
+++ b/zon_blog_extensions.php
@@ -5,8 +5,8 @@
  * Plugin Name:       ZEIT ONLINE Blog Options
  * Plugin URI:        https://github.com/ZeitOnline/zon-blog-extensions
  * Description:       Add ZEIT ONLINE specific options to wordpress weblogs
- * Version:           1.1.1
- * Author:            Arne Seemann, Moritz Stoltenburg
+ * Version:           1.2
+ * Author:            Arne Seemann, Moritz Stoltenburg, Nico Brünjes
  * Author URI:        http://www.zeit.de
  * License:           GPL-3.0+
  * License URI:       http://www.gnu.org/licenses/gpl-3.0.txt
@@ -25,6 +25,7 @@ class ZonOptionsPage
 	private $_ressort;
 	private $_ad_id;
 	private $_p_length;
+	private $_gdpr_act;
 
 	private $_zon_navigation_url = 'http://static.zeit.de/data/navigation-v2.xml';
 
@@ -68,6 +69,7 @@ class ZonOptionsPage
 		$this->_ad_id    = get_option( 'zon_bannerkennung' );
 		$this->_no_ads 	 = get_option( 'zon_ads_deactivated' );
 		$this->_p_length = get_option( 'zon_ads_paragraph_length', 200 );
+		$this->_gdpr_act = get_option( 'zon_gdpr_activated', 1 );
 
 		?>
 		<div class="wrap">
@@ -119,6 +121,12 @@ class ZonOptionsPage
 			'intval'
 		);
 
+		register_setting(
+			'zon_blog_options',
+			'zon_gdpr_activated',
+			'intval'
+		);
+
 		/**
 		 * Add sections
 		 */
@@ -133,6 +141,13 @@ class ZonOptionsPage
 		add_settings_section(
 			'settings_ads',
 			'Produktmanagement',
+			null,
+			'zon-options-page'
+		);
+
+		add_settings_section(
+			'settings_gdpr',
+			'Datenschutz',
 			null,
 			'zon-options-page'
 		);
@@ -175,6 +190,15 @@ class ZonOptionsPage
 			'zon-options-page',
 			'settings_ads',
 			array( 'id' => 'zon_ads_deactivated' )
+		);
+
+		add_settings_field(
+			'zon_gdpr_activated',
+			'DSGVO Infolayer',
+			array( $this, 'render_field' ),
+			'zon-options-page',
+			'settings_gdpr',
+			array( 'id' => 'zon_gdpr_activated' )
 		);
 
 	}
@@ -237,6 +261,15 @@ class ZonOptionsPage
 						'Geschäftsführung auf das Deaktivieren von Ads geeinigt haben. Bitte nicht selbständig aktivieren. ' .
 						'Ist der Haken gesetzt, werden - sofern das Theme darauf vorbereitet ist - keine Anzeigen ausgespielt.'
 					)
+				);
+				break;
+
+			case 'zon_gdpr_activated':
+				printf(
+					'<label><input type="checkbox" id="%1$s" name="%1$s" value="1" %2$s> DSGVO Infolayer aktiviert.</label><p class="description">%3$s</p>',
+					$args['id'],
+					checked( 1, $this->_gdpr_act, false ),
+					'Es wird ein Infolayer angezeigt, der auf die Nutzung von Cookies hinweist. Dieser muss zusammen mit dem Seitenrahmen geholt werden.'
 				);
 				break;
 		}
@@ -382,6 +415,12 @@ if ( is_admin() ) {
 require plugin_dir_path( __FILE__ ) . 'zon_webtrekk.php';
 add_action( 'wp_footer', 'webtrekk_tracking_code' );
 
+
+/**
+ * add GDPR Layer
+ */
+require plugin_dir_path( __FILE__ ) . 'zon_gdpr_layer.php';
+add_action( 'zon_theme_after_opening_body', 'gdpr_layer' );
 
 /**
  * register IVW tracking

--- a/zon_gdpr_layer.php
+++ b/zon_gdpr_layer.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * @package ZEIT ONLINE Blog Options
+ *
+ * Author:            Nico Brünjes
+ * Author URI:        http://www.zeit.de
+ * License:           GPL-3.0+
+ * License URI:       http://www.gnu.org/licenses/gpl-3.0.txt
+*/
+
+function gdpr_layer() {
+	if ( get_option( 'zon_gdpr_activated', 1 ) == 1 ) {
+		echo "\n<script>document.body.setAttribute('data-gdpr-layer', 'true');</script>\n";
+	}
+}


### PR DESCRIPTION
Adds the ability to activate the previously downloaded gdpr layer script. It is on by default and per blog cancelable. 

Nice to know: the use of the plugin zon-blog-options is madantory on our blog platform.